### PR TITLE
document.ready() used in the main page and the JS script

### DIFF
--- a/js/news.js
+++ b/js/news.js
@@ -1,29 +1,26 @@
-$(document).ready(function() {
+var ajax_baseurl = '../plugins/news/ajax';
+var path = document.location.pathname;
+// construct url for plugin pages
+if (path.indexOf('plugins/') !== -1) {
+   var plugin_path = path.substring(path.indexOf('plugins'));
+   var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
+   var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
+}
 
-   var ajax_baseurl = '../plugins/news/ajax';
-   var path = document.location.pathname;
-   // construct url for plugin pages
-   if (path.indexOf('plugins/') !== -1) {
-      var plugin_path = path.substring(path.indexOf('plugins'));
-      var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
-      var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
-   }
+pluginNewsCloseAlerts = function() {
+   $(document).on("click", "a.plugin_news_alert-close",function() {
+      var alert = $(this).parent(".plugin_news_alert");
+      var id    = alert.attr('data-id');
+      $.post(ajax_baseurl+"/hide_alert.php", {'id' : id})
+         .done(function() {
+            alert.remove();
+         });
+   });
+};
 
-   pluginNewsCloseAlerts = function() {
-      $(document).on("click", "a.plugin_news_alert-close",function() {
-         var alert = $(this).parent(".plugin_news_alert");
-         var id    = alert.attr('data-id');
-         $.post(ajax_baseurl+"/hide_alert.php", {'id' : id})
-            .done(function() {
-               alert.remove();
-            });
-      });
-   };
-
-   pluginNewsToggleAlerts = function() {
-      $(document).on("click", ".plugin_news_alert-toggle",function() {
-         var alert = $(this).parent(".plugin_news_alert");
-         alert.toggleClass('expanded');
-      });
-   }
-});
+pluginNewsToggleAlerts = function() {
+   $(document).on("click", ".plugin_news_alert-toggle",function() {
+      var alert = $(this).parent(".plugin_news_alert");
+      alert.toggleClass('expanded');
+   });
+}

--- a/js/news.js
+++ b/js/news.js
@@ -1,11 +1,13 @@
-var ajax_baseurl = '../plugins/news/ajax';
-var path = document.location.pathname;
-// construct url for plugin pages
-if (path.indexOf('plugins/') !== -1) {
-   var plugin_path = path.substring(path.indexOf('plugins'));
-   var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
-   var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
-}
+$(document).ready(function() {
+   var ajax_baseurl = '../plugins/news/ajax';
+   var path = document.location.pathname;
+   // construct url for plugin pages
+   if (path.indexOf('plugins/') !== -1) {
+      var plugin_path = path.substring(path.indexOf('plugins'));
+      var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
+      var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
+   }
+});
 
 pluginNewsCloseAlerts = function() {
    $(document).on("click", "a.plugin_news_alert-close",function() {

--- a/setup.php
+++ b/setup.php
@@ -34,7 +34,7 @@ function plugin_init_news() {
       Plugin::registerClass('PluginNewsProfile', ['addtabon' => 'Profile']);
 
       $PLUGIN_HOOKS['add_css']['news'] = 'css/styles.css';
-      $PLUGIN_HOOKS['add_javascript']['news'] = "js/news.js";
+      $PLUGIN_HOOKS['add_javascript']['news'][] = "js/news.js";
       $PLUGIN_HOOKS['display_login']['news'] = [
          "PluginNewsAlert", "displayOnLogin"
       ];


### PR DESCRIPTION
I think this might make the plugin to malfunction.

At least it breaks Formcreator's service catalog due to the following error

![image](https://user-images.githubusercontent.com/14139801/31034758-b171811c-a565-11e7-832f-4d7443e13ae7.png)

```javascript
$(document).ready(function() {
         pluginNewsCloseAlerts();
         pluginNewsToggleAlerts();
      })
```

and in the file js/news.js there is (again) a $(document).ready() usage.