### PR TITLE
prevent notice

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -491,11 +491,14 @@ class PluginNewsAlert extends CommonDBTM {
    static function preItemForm($params = []) {
       if (isset($params['item'])
           && $params['item'] instanceof CommonITILObject) {
-         $item     = $params['item'];
-         $itemtype = get_class($item);
+         $item        = $params['item'];
+         $itemtype    = get_class($item);
+         $entities_id = isset($params['item']->fields['entities_id'])
+            ? $params['item']->fields['entities_id']
+            : 0;
          self::displayAlerts(['show_helpdesk_alerts' => true,
                               'show_hidden_alerts'   => false,
-                              'entities_id'          => $params['item']->fields['entities_id']
+                              'entities_id'          => $entities_id
                              ]);
          echo "</br>";
       }


### PR DESCRIPTION
```
2017-11-15 14:30:31 [1106@bwgpidev]
   *** PHP Notice(8): Undefined index: entities_id
   Backtrace :
   plugins/news/inc/alert.class.php:498
   inc/plugin.class.php:1271                          PluginNewsAlert::preItemForm()
   inc/ticket.class.php:3904                          Plugin::doHook()
   inc/tickettemplate.class.php:561                   Ticket->showFormHelpdesk()
   inc/tickettemplate.class.php:333                   TicketTemplate::showHelpdeskPreview()
   inc/commonglpi.class.php:482                       TicketTemplate::displayTabContentForItem()
   ajax/common.tabs.php:96                            CommonGLPI::displayStandardTab()
```