### PR TITLE
Refactoring ajax_base url declaration, because alert hiding doesn't work

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -469,11 +469,6 @@ class PluginNewsAlert extends CommonDBTM {
          echo Html::script($prefix."/lib/jquery/js/jquery-ui-1.10.4.custom.min.js");
          echo Html::script($prefix."/plugins/news/js/news.js");
       }
-
-      echo Html::scriptBlock("$(document).ready(function() {
-         pluginNewsCloseAlerts();
-         pluginNewsToggleAlerts();
-      })");
    }
 
    static function getTypes() {

--- a/js/news.js
+++ b/js/news.js
@@ -5,7 +5,7 @@ pluginNewsGetBaseUrl = function() {
    if (path.indexOf('plugins/') !== -1) {
       var plugin_path = path.substring(path.indexOf('plugins'));
       var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
-      var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
+      ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
    }
 
    return ajax_baseurl;

--- a/js/news.js
+++ b/js/news.js
@@ -29,3 +29,13 @@ pluginNewsToggleAlerts = function() {
       alert.toggleClass('expanded');
    });
 }
+
+$(document).ready(function() {
+   pluginNewsCloseAlerts();
+   pluginNewsToggleAlerts();
+
+   $(".glpi_tabs").on("tabsload", function(event, ui) {
+      pluginNewsCloseAlerts();
+      pluginNewsToggleAlerts();
+   });
+});

--- a/js/news.js
+++ b/js/news.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+pluginNewsGetBaseUrl = function() {
    var ajax_baseurl = '../plugins/news/ajax';
    var path = document.location.pathname;
    // construct url for plugin pages
@@ -7,12 +7,15 @@ $(document).ready(function() {
       var nb_directory = (plugin_path.match(/\//g) || []).length + 1;
       var ajax_baseurl = Array(nb_directory).join("../") + 'plugins/news/ajax';
    }
-});
+
+   return ajax_baseurl;
+};
 
 pluginNewsCloseAlerts = function() {
    $(document).on("click", "a.plugin_news_alert-close",function() {
       var alert = $(this).parent(".plugin_news_alert");
       var id    = alert.attr('data-id');
+      var ajax_baseurl = pluginNewsGetBaseUrl();
       $.post(ajax_baseurl+"/hide_alert.php", {'id' : id})
          .done(function() {
             alert.remove();


### PR DESCRIPTION
Hello,

Actually we can't hide alerts with plugin news, because of the declaration of variable ajax_baseurl in document ready function.

With this PR it's solved !