### PR TITLE
Delete alert_target rights

### DIFF
--- a/inc/alert_target.class.php
+++ b/inc/alert_target.class.php
@@ -33,7 +33,11 @@ class PluginNewsAlert_Target extends CommonDBTM {
    }
 
    static function canDelete() {
-      return self::canPurge();
+      return self::canUpdate();
+   }
+
+   static function canPurge() {
+      return self::canUpdate();
    }
 
    static function getSpecificValueToDisplay($field, $values, array $options = []) {


### PR DESCRIPTION
Following #67

Allow to delete an alert target if you are allowed to edit an alert.

Internal ref : 16000