### PR TITLE
Fix pre_item_form hook

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -47,7 +47,7 @@ function plugin_init_news() {
          "PluginNewsAlert", "displayOnCentral"
       ];
 
-      $PLUGIN_HOOKS['pre_item_form']['alert'] = ['PluginNewsAlert', 'preItemForm'];
+      $PLUGIN_HOOKS['pre_item_form']['news'] = ['PluginNewsAlert', 'preItemForm'];
 
       if (Session::haveRight('reminder_public', READ)) {
          $PLUGIN_HOOKS['menu_toadd']['news'] = [


### PR DESCRIPTION
Alert does not show on the tickets page for the helpdesk in GLPI 9.4.

The pre_item_form hook was ignored because the `Plugin::isPluginLoaded($plug)` check failed as $plug was 'alert' while the loaded plugin name was 'news'.

