### PR TITLE
fix: prevent SQL error when glpiactiveprofile is null

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -214,7 +214,7 @@ class PluginNewsAlert extends CommonDBTM {
       $login_show_hidden_sql = " `$utable`.`id` IS NULL ";
       $entity_sql            = "";
       $show_helpdesk_sql     = '';
-      if (isset($_SESSION['glpiID'])) {
+      if (isset($_SESSION['glpiID']) && isset($_SESSION['glpiactiveprofile']['id'])) {
          $targets_sql = "AND (
                            `$ttable`.`itemtype` = 'Profile'
                            AND (


### PR DESCRIPTION
This fix prevent this kind of SQL error to be triggered when $_SESSION['glpiactiveprofile']['id'] is not set (don't ask me how it's possible).

```
inc/dbmysql.class.php line 306
  *** MySQL query error:
  SQL: SELECT DISTINCT `glpi_plugin_news_alerts`.`id`, `glpi_plugin_news_alerts`.*
                  FROM `glpi_plugin_news_alerts`
                  LEFT JOIN `glpi_plugin_news_alerts_users`
                     ON `glpi_plugin_news_alerts_users`.`plugin_news_alerts_id` = `glpi_plugin_news_alerts`.`id`
                     AND `glpi_plugin_news_alerts_users`.`users_id` = 2894
                     AND `glpi_plugin_news_alerts_users`.`state` = 1
                  INNER JOIN `glpi_plugin_news_alerts_targets`
                     ON `glpi_plugin_news_alerts_targets`.`plugin_news_alerts_id` = `glpi_plugin_news_alerts`.`id`
                  AND (
                           `glpi_plugin_news_alerts_targets`.`itemtype` = 'Profile'
                           AND (
                              `glpi_plugin_news_alerts_targets`.`items_id` = 
                              OR `glpi_plugin_news_alerts_targets`.`items_id` = -1
                           )
                           OR `glpi_plugin_news_alerts_targets`.`itemtype` = 'Group'
                              AND `glpi_plugin_news_alerts_targets`.`items_id` IN (-1)
                           OR `glpi_plugin_news_alerts_targets`.`itemtype` = 'User'
                              AND `glpi_plugin_news_alerts_targets`.`items_id` = 2894
                        )
                  WHERE ( `glpi_plugin_news_alerts_users`.`id` IS NULL   )
                     AND (`glpi_plugin_news_alerts`.`date_start` < '2021-01-19 14:53:35'
                           OR `glpi_plugin_news_alerts`.`date_start` = '2021-01-19 14:53:35'
                           OR `glpi_plugin_news_alerts`.`date_start` IS NULL
                     )
                     AND (`glpi_plugin_news_alerts`.`date_end` IS NULL
                           OR `glpi_plugin_news_alerts`.`date_end` > '2021-01-19 14:53:35'
                           OR `glpi_plugin_news_alerts`.`date_end` = '2021-01-19 14:53:35'
                     )
                  AND `is_deleted`='0' AND `is_active`='1'
                  
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'OR `glpi_plugin_news_alerts_targets`.`items_id` = -1
                           ' at line 13
  Backtrace :
  inc/dbmysqliterator.class.php:95                   
  inc/dbmysql.class.php:857                          DBmysqlIterator->execute()
  plugins/news/inc/alert.class.php:266               DBmysql->request()
  plugins/news/inc/alert.class.php:442               PluginNewsAlert::findAllToNotify()
  plugins/news/inc/alert.class.php:426               PluginNewsAlert::displayAlerts()
  inc/plugin.class.php:1286                          PluginNewsAlert::displayOnLogin()
  index.php:222                                      Plugin::doHook()
```