### PR TITLE
Fix(display): do not display hidden helpdesk alert

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -29,17 +29,18 @@ function plugin_news_install() {
    if (! $DB->tableExists('glpi_plugin_news_alerts')) {
       $DB->query("
          CREATE TABLE IF NOT EXISTS `glpi_plugin_news_alerts` (
-         `id`                   INT NOT NULL AUTO_INCREMENT,
-         `date_mod`             TIMESTAMP NOT NULL,
-         `name`                 VARCHAR(255) NOT NULL,
-         `message`              TEXT NOT NULL,
-         `date_start`           TIMESTAMP NULL DEFAULT NULL,
-         `date_end`             TIMESTAMP NULL DEFAULT NULL,
-         `type`                 INT NOT NULL,
-         `is_deleted`           TINYINT(1) NOT NULL DEFAULT 0,
-         `is_displayed_onlogin` TINYINT(1) NOT NULL,
-         `entities_id`          INT NOT NULL,
-         `is_recursive`         TINYINT(1) NOT NULL DEFAULT 1,
+         `id`                       INT NOT NULL AUTO_INCREMENT,
+         `date_mod`                 TIMESTAMP NOT NULL,
+         `name`                     VARCHAR(255) NOT NULL,
+         `message`                  TEXT NOT NULL,
+         `date_start`               TIMESTAMP NULL DEFAULT NULL,
+         `date_end`                 TIMESTAMP NULL DEFAULT NULL,
+         `type`                     INT NOT NULL,
+         `is_deleted`               TINYINT(1) NOT NULL DEFAULT 0,
+         `is_displayed_onlogin`     TINYINT(1) NOT NULL,
+         `is_displayed_oncentral`   TINYINT(1) NOT NULL,
+         `entities_id`              INT NOT NULL,
+         `is_recursive`             TINYINT(1) NOT NULL DEFAULT 1,
          PRIMARY KEY (`id`)
          ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
       ");

--- a/hook.php
+++ b/hook.php
@@ -151,6 +151,11 @@ function plugin_news_install() {
                      ('PluginNewsAlert', 6, 4, 0)");
    }
 
+   // add displayed on central flag
+   if (!$DB->fieldExists("glpi_plugin_news_alerts", "is_displayed_oncentral")) {
+      $migration->addField("glpi_plugin_news_alerts", "is_displayed_oncentral", 'bool', ['value' => true]);
+   }
+
    $migration->migrationOneTable("glpi_plugin_news_alerts");
    return true;
 }

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -467,6 +467,7 @@ class PluginNewsAlert extends CommonDBTM {
       }
       if (!$p['show_only_login_alerts']
          && $alerts = self::findAllToNotify(['show_only_login_alerts' => false,
+                                             'show_only_helpdesk_alerts' => true,
                                              'show_hidden_alerts'     => true])
           && !$p['show_hidden_alerts']) {
          echo "<div class='center'>";

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -465,10 +465,16 @@ class PluginNewsAlert extends CommonDBTM {
             echo "</div>";
          }
       }
+
+      $hidden_params = [
+         'show_hidden_alerts'          => true,
+         'show_only_login_alerts'      => false,
+         'show_only_helpdesk_alerts'   => true,
+         'entities_id'                 => $p['entities_id']
+      ];
+
       if (!$p['show_only_login_alerts']
-         && $alerts = self::findAllToNotify(['show_only_login_alerts' => false,
-                                             'show_only_helpdesk_alerts' => true,
-                                             'show_hidden_alerts'     => true])
+         && $alerts = self::findAllToNotify($hidden_params)
           && !$p['show_hidden_alerts']) {
          echo "<div class='center'>";
          echo "<a href='".Plugin::getWebDir('news')."/front/hidden_alerts.php'>";

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -425,7 +425,6 @@ class PluginNewsAlert extends CommonDBTM {
       echo '</td>';
       echo '</tr>';
 
-
       $this->showFormButtons($options);
    }
 

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -181,7 +181,7 @@ class PluginNewsAlert extends CommonDBTM {
       global $DB;
 
       $p['show_only_login_alerts']     = false;
-      $p['show_alert_on_central']      = false;
+      $p['show_only_central_alerts']   = false;
       $p['show_hidden_alerts']         = false;
       $p['show_only_helpdesk_alerts']  = false;
       $p['entities_id']                = false;
@@ -236,7 +236,7 @@ class PluginNewsAlert extends CommonDBTM {
          $login_show_hidden_sql = " `$utable`.`id` IS NOT NULL";
       }
 
-      if ($p['show_alert_on_central']) {
+      if ($p['show_only_central_alerts']) {
          //dont show central alert if they should no longer be visible
          $show_central_sql = " AND `$table`.`is_displayed_oncentral`='1'";
       }
@@ -430,7 +430,7 @@ class PluginNewsAlert extends CommonDBTM {
 
    static function displayOnCentral() {
       echo "<tr><th colspan='2'>";
-      self::displayAlerts(['show_alert_on_central' => true]);
+      self::displayAlerts(['show_only_central_alerts' => true]);
       echo "</th></tr>";
    }
 
@@ -445,7 +445,7 @@ class PluginNewsAlert extends CommonDBTM {
       global $CFG_GLPI;
 
       $p['show_only_login_alerts']     = false;
-      $p['show_alert_on_central']      = false;
+      $p['show_only_central_alerts']      = false;
       $p['show_hidden_alerts']         = false;
       $p['show_only_helpdesk_alerts']  = false;
       $p['entities_id']                = false;
@@ -484,7 +484,7 @@ class PluginNewsAlert extends CommonDBTM {
       $hidden_params = [
          'show_hidden_alerts'          => true,
          'show_only_login_alerts'      => false,
-         'show_alert_on_central'       => $p['show_alert_on_central'],
+         'show_only_central_alerts'    => $p['show_only_central_alerts'],
          'show_only_helpdesk_alerts'   => $p['show_only_helpdesk_alerts'],
          'entities_id'                 => $p['entities_id']
       ];

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -231,7 +231,8 @@ class PluginNewsAlert extends CommonDBTM {
       }
 
       if ($p['show_hidden_alerts']) {
-         $login_show_hidden_sql = " `$utable`.`id` IS NOT NULL ";
+         //dont show hidden alert if they should no longer be visible
+         $login_show_hidden_sql = " `$utable`.`id` IS NOT NULL AND ( `$table`.`is_displayed_onhelpdesk`='1' OR `$table`.`is_displayed_onlogin`='1')";
       }
 
       //If the alert must be displayed on helpdesk form : filter by ticket's entity
@@ -416,7 +417,7 @@ class PluginNewsAlert extends CommonDBTM {
 
    static function displayOnCentral() {
       echo "<tr><th colspan='2'>";
-      self::displayAlerts(['show_only_helpdesk_alerts' => Session::getCurrentInterface() == 'central']);
+      self::displayAlerts();
       echo "</th></tr>";
    }
 

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -416,7 +416,7 @@ class PluginNewsAlert extends CommonDBTM {
 
    static function displayOnCentral() {
       echo "<tr><th colspan='2'>";
-      self::displayAlerts(['show_only_helpdesk_alerts' => Session::getCurrentInterface() == 'helpdesk']);
+      self::displayAlerts(['show_only_helpdesk_alerts' => Session::getCurrentInterface() == 'central']);
       echo "</th></tr>";
    }
 
@@ -469,7 +469,7 @@ class PluginNewsAlert extends CommonDBTM {
       $hidden_params = [
          'show_hidden_alerts'          => true,
          'show_only_login_alerts'      => false,
-         'show_only_helpdesk_alerts'   => true,
+         'show_only_helpdesk_alerts'   => $p['show_only_helpdesk_alerts'],
          'entities_id'                 => $p['entities_id']
       ];
 

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -181,6 +181,7 @@ class PluginNewsAlert extends CommonDBTM {
       global $DB;
 
       $p['show_only_login_alerts']     = false;
+      $p['show_alert_on_central']      = false;
       $p['show_hidden_alerts']         = false;
       $p['show_only_helpdesk_alerts']  = false;
       $p['entities_id']                = false;
@@ -232,7 +233,12 @@ class PluginNewsAlert extends CommonDBTM {
 
       if ($p['show_hidden_alerts']) {
          //dont show hidden alert if they should no longer be visible
-         $login_show_hidden_sql = " `$utable`.`id` IS NOT NULL AND ( `$table`.`is_displayed_onhelpdesk`='1' OR `$table`.`is_displayed_onlogin`='1')";
+         $login_show_hidden_sql = " `$utable`.`id` IS NOT NULL";
+      }
+
+      if ($p['show_alert_on_central']) {
+         //dont show central alert if they should no longer be visible
+         $show_central_sql = " AND `$table`.`is_displayed_oncentral`='1'";
       }
 
       //If the alert must be displayed on helpdesk form : filter by ticket's entity
@@ -253,7 +259,7 @@ class PluginNewsAlert extends CommonDBTM {
                   INNER JOIN `$ttable`
                      ON `$ttable`.`plugin_news_alerts_id` = `$table`.`id`
                   $targets_sql
-                  WHERE ($login_show_hidden_sql $login_sql $show_helpdesk_sql)
+                  WHERE ($login_show_hidden_sql $login_sql $show_central_sql $show_helpdesk_sql)
                      AND (`$table`.`date_start` < '$today'
                            OR `$table`.`date_start` = '$today'
                            OR `$table`.`date_start` IS NULL
@@ -409,15 +415,23 @@ class PluginNewsAlert extends CommonDBTM {
       echo '<td>';
       Dropdown::showYesNo('is_displayed_onhelpdesk', $this->fields['is_displayed_onhelpdesk']);
       echo '</td>';
-
       echo '</tr>';
+
+      echo '<tr>';
+      echo '<td>' . __("Show on central page", 'news') .'</td>';
+      echo '</td>';
+      echo '<td>';
+      Dropdown::showYesNo('is_displayed_oncentral', $this->fields['is_displayed_oncentral']);
+      echo '</td>';
+      echo '</tr>';
+
 
       $this->showFormButtons($options);
    }
 
    static function displayOnCentral() {
       echo "<tr><th colspan='2'>";
-      self::displayAlerts();
+      self::displayAlerts(['show_alert_on_central' => true]);
       echo "</th></tr>";
    }
 
@@ -432,6 +446,7 @@ class PluginNewsAlert extends CommonDBTM {
       global $CFG_GLPI;
 
       $p['show_only_login_alerts']     = false;
+      $p['show_alert_on_central']      = false;
       $p['show_hidden_alerts']         = false;
       $p['show_only_helpdesk_alerts']  = false;
       $p['entities_id']                = false;
@@ -470,6 +485,7 @@ class PluginNewsAlert extends CommonDBTM {
       $hidden_params = [
          'show_hidden_alerts'          => true,
          'show_only_login_alerts'      => false,
+         'show_alert_on_central'       => $p['show_alert_on_central'],
          'show_only_helpdesk_alerts'   => $p['show_only_helpdesk_alerts'],
          'entities_id'                 => $p['entities_id']
       ];


### PR DESCRIPTION
Alerts closed by the user are always displayed (as hidden) even if the option "show on page helpdesk" is set to "no".

This Pr fix this

Internal 21399