### PR TITLE
Hide empty container

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -76,3 +76,7 @@
 .plugin_news_alert-visibility {
    margin: 0 auto;
 }
+
+.plugin_news_alert-container:empty {
+   display: none;
+}


### PR DESCRIPTION
Hide alert container when it doesn't contain anything to avoid it wasting space with its padding and margin.