### PR TITLE
Fix display of 'All profiles' in alerts list

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -123,7 +123,7 @@ class PluginNewsAlert extends CommonDBTM {
          'datatype'         => 'specific',
          'forcegroupby'     => true,
          'joinparams'       => ['jointype' => 'child'],
-         'additionalfields' => ['itemtype'],
+         'additionalfields' => ['itemtype', 'all_items'],
       ];
 
       $tab[] = [


### PR DESCRIPTION
Since #105 , following issue appears on alerts list.

```
PHP Warning: Undefined array key "all_items" in \glpi\plugins\news\inc\alert_target.class.php on line 73
```