### PR TITLE
Fix expand and collapse of alert messages

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -520,9 +520,9 @@ class PluginNewsAlert extends CommonDBTM {
                             <div class='text-muted'>
                                 $date_start$date_end
                             </div>
-                            <p class='mt-2 plugin_news_alert-content'>
+                            <div class='mt-2 plugin_news_alert-content'>
                                 $content
-                            </p>
+                            </div>
                         </div>
                     </div>
                     $close_tag


### PR DESCRIPTION
Alert content can be richtext and nested `p` tags are not allowed. It pushes the content out of the wrapper `p` element which breaks the expand/collapse. Before the GLPI 10 compatibility changes, the content wrapper was a `div`.

Fixes glpi-project/glpi#11836