### PR TITLE
Alert form: fix missing richtext editor

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -375,8 +375,8 @@ class PluginNewsAlert extends CommonDBTM {
       echo '<tr>';
       echo '<td>' . __('Description') .'</td>';
       echo '<td colspan="3">';
-      echo '<textarea name="message" rows="12" cols="80" class="form-control">'.$this->getField('message').'</textarea>';
-      Html::initEditorSystem('message');
+      echo '<textarea id="plugin_news_message_field" name="message" rows="12" cols="80" class="form-control">'.$this->getField('message').'</textarea>';
+      Html::initEditorSystem('plugin_news_message_field');
       echo '</td>';
       echo '</tr>';
 


### PR DESCRIPTION
This field is supposed to be using rich text: 

![image](https://user-images.githubusercontent.com/42734840/186129844-35ff8925-6ea0-4dcd-b096-b76008b64dc0.png)

After fix:

![image](https://user-images.githubusercontent.com/42734840/186129970-fd70e000-d186-4a84-808a-aba31810959c.png)

It seems like `Html::initEditorSystem` expected a textarea name in the past (the field is displayed correctly in GLPI 9.5) but now it expect an ID.
