### PR TITLE
Fix of alert text wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+
+## [1.12.1] - 2024-04-02
+
+### Added
+
+### Fixed
+
+- Fix of alert text wrapping to prevent it from going outside the div of its alert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-
-## [1.12.1] - 2024-04-02
-
-### Added
-
 ### Fixed
 
-- Fix of alert text wrapping to prevent it from going outside the div of its alert
+- Improve alert text wrapping, preventing it from going outside the content of its parent

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -503,6 +503,10 @@ class PluginNewsAlert extends CommonDBTM
     */
     public static function getSizeClasses(string $size): string
     {
+        // Note: the 'w-100' class will be added using javascript when we are
+        // displaying ITIL forms.
+        // See display_alert.html.twig for more details.
+
         switch ($size) {
             case self::SMALL:
                 return "col-xxl-4 col-xl-4 col-12";
@@ -515,7 +519,7 @@ class PluginNewsAlert extends CommonDBTM
                 return "col-xxl-8 col-xl-8 col-12";
 
             case self::MAXIMUM:
-                return "w-100";
+                return "col-12";
         }
     }
 

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -515,7 +515,7 @@ class PluginNewsAlert extends CommonDBTM
                 return "col-xxl-8 col-xl-8 col-12";
 
             case self::MAXIMUM:
-                return "col-12";
+                return "w-100";
         }
     }
 

--- a/templates/alert_form.html.twig
+++ b/templates/alert_form.html.twig
@@ -120,7 +120,9 @@
         item.fields.size,
         sizes,
         __('Size', 'news'),
-        base_option_small
+        {
+            'helper': __("For Tickets, Changes and Problems forms, the alert size is automatically set to the maximum size.")
+        }|merge(base_option_small)
     ) }}
     {{ news_fields.iconField(
         "icon",

--- a/templates/display_alert.html.twig
+++ b/templates/display_alert.html.twig
@@ -39,7 +39,7 @@
     <div
         class="
             alert-{{ js_rand }}
-            alert text-start bg-{{ alert_fields.background_color }}
+            alert bg-{{ alert_fields.background_color }}
             {{ can_close ? "alert-dismissible"  : ""}}
         "
         style="
@@ -49,7 +49,7 @@
     >
         <div class="d-flex">
             <i class="ti ti-{{ alert_fields.icon }} fa-2x me-2"></i>
-            <div>
+            <div class="overflow-hidden">
                 <h3 class="mt-1">
                     {{ alert_fields.name|verbatim_value  }}
                     {% if show_only_login_alerts %}
@@ -72,7 +72,7 @@
                         {{ alert_fields.date_end|formatted_datetime }}
                     </div>
                 {% endif %}
-                <div class="mt-2 plugin_news_alert-content">
+                <div class="plugin_news_alert-content overflow-hidden">
                     {{ content|safe_html }}
                 </div>
             </div>

--- a/templates/display_alert.html.twig
+++ b/templates/display_alert.html.twig
@@ -34,7 +34,6 @@
 </style>
 
 {% set js_rand = random() %}
-
 <div class="plugin_news_alert {{ size }}" data-id="{{ alert_fields.id|default(0) }}">
     <div
         class="
@@ -101,4 +100,11 @@
             )
         }
     })();
+    var formElement = document.querySelector('form[id="itil-form"]');
+        if (formElement) {
+            var currentElement = formElement.querySelector('.plugin_news_alert');
+            if (currentElement) {
+                currentElement.className = 'plugin_news_alert w-100';
+            }
+        }
 </script>

--- a/templates/display_alert.html.twig
+++ b/templates/display_alert.html.twig
@@ -99,12 +99,14 @@
                     .replace(')', ', 0.6)')
             )
         }
+
+        // ITIL form has a specified layout, we must always display the full size
+        // alert.
+        // The "col-12" class can't be directly used for this purpose because
+        // a GLPI's core script will automatically replace it by "col-6" when
+        // expending the sidebar.
+        $('form[id="itil-form"]')
+            .find('.plugin_news_alert')
+            .addClass('w-100');
     })();
-    var formElement = document.querySelector('form[id="itil-form"]');
-        if (formElement) {
-            var currentElement = formElement.querySelector('.plugin_news_alert');
-            if (currentElement) {
-                currentElement.className = 'plugin_news_alert w-100';
-            }
-        }
 </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !32277

Correction of alert text wrapping to prevent it from going outside the div of its alert

**Before :** 
![image](https://github.com/pluginsGLPI/news/assets/107540223/4f9994ba-9a21-4408-9bce-a0dff82a9249)

**After :** 
![image](https://github.com/pluginsGLPI/news/assets/107540223/466dbd11-b0cd-4648-a4e9-080ca6d80d0b)![image](https://github.com/pluginsGLPI/news/assets/107540223/f1df720a-351b-425c-b68a-699f6a2e59ea)
