### PR TITLE
Fix SQL query that finds alerts to display to the user

### DIFF
--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -285,26 +285,30 @@ class PluginNewsAlert extends CommonDBTM
         $show_central_sql      = [];
         if (isset($_SESSION['glpiID']) && isset($_SESSION['glpiactiveprofile']['id'])) {
             $targets_sql = [
-                'OR' => [
+                'AND' => [
                     [
-                        'AND' => [
-                            "$ttable.itemtype" => 'Profile',
-                            'OR' => [
-                                "$ttable.items_id" => $_SESSION['glpiactiveprofile']['id'],
-                                "$ttable.all_items" => 1,
+                        'OR' => [
+                            [
+                                'AND' => [
+                                    "$ttable.itemtype" => 'Profile',
+                                    'OR' => [
+                                        "$ttable.items_id" => $_SESSION['glpiactiveprofile']['id'],
+                                        "$ttable.all_items" => 1,
+                                    ],
+                                ]
                             ],
-                        ]
-                    ],
-                    [
-                        'AND' => [
-                            "$ttable.itemtype" => 'Group',
-                            "$ttable.items_id" => $fndgroup,
-                        ]
-                    ],
-                    [
-                        'AND' => [
-                            "$ttable.itemtype" => 'User',
-                            "$ttable.items_id" => $_SESSION['glpiID'],
+                            [
+                                'AND' => [
+                                    "$ttable.itemtype" => 'Group',
+                                    "$ttable.items_id" => $fndgroup,
+                                ]
+                            ],
+                            [
+                                'AND' => [
+                                    "$ttable.itemtype" => 'User',
+                                    "$ttable.items_id" => $_SESSION['glpiID'],
+                                ]
+                            ],
                         ]
                     ],
                 ]


### PR DESCRIPTION
If a target is configured for an Alert. Ex: Alerts 1 :
![image](https://github.com/pluginsGLPI/news/assets/102067890/fe604e46-9099-4986-9dce-9280014241fa)

If we log in with a profile that is not one of the targets, we still see the alert.
![image](https://github.com/pluginsGLPI/news/assets/102067890/4a7ff820-6053-435a-b816-f7514fd899ef)

Related ticket : !32722