### PR TITLE
fix(login): text overflow on login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for displaying alerts on the service catalog page.
 
+### Fixed
+
+- Fix alert overflow on large login screens.
+
 ## [1.13.0] - 2025-09-22
 
 ### Added

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -626,8 +626,9 @@ class PluginNewsAlert extends CommonDBTM
     public static function displayAlert($alert, $p)
     {
         $twig = TemplateRenderer::getInstance();
+        $size = $p['show_only_login_alerts'] ? 'col-12' : self::getSizeClasses($alert['size']);
         $twig->display('@news/display_alert.html.twig', [
-            'size'                   => self::getSizeClasses($alert['size']),
+            'size'                   => $size,
             'alert_fields'           => $alert,
             'content'                => $alert['message'],
             'can_close'              => $alert['is_close_allowed'] && !$p['show_hidden_alerts'],


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !40676

Fixes the issue where alert text overflows outside the card boundaries on the login page when the screen width is >= 1200px.

Bootstrap's `col-*` classes (e.g., `col-xxl-4`, `col-xl-6`) calculate dimensions as percentages of the parent container width. On the login page, the parent container (`col-auto`) has no defined width, causing percentage-based column classes to fail and breaking the alert layout.

Use `col-12` (100% width) for alerts displayed on the login page. Since 100% of any width equals the full available space, this works reliably in all contexts. For other pages (central, helpdesk), alerts continue to use their configured size classes.

## Screenshots (if appropriate):
<img width="961" height="746" alt="image" src="https://github.com/user-attachments/assets/1e787b71-53fe-47b2-a576-11858b8dbde3" />

