### PR TITLE
FEATURE / Displaying News alerts on Service Catalog page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added support for displaying alerts on the service catalog page.
+
 ## [1.13.0] - 2025-09-22
 
 ### Added

--- a/hook.php
+++ b/hook.php
@@ -55,8 +55,9 @@ function plugin_news_install()
          `date_end`                 TIMESTAMP NULL DEFAULT NULL,
          `type`                     INT NOT NULL,
          `is_deleted`               TINYINT NOT NULL DEFAULT 0,
-         `is_displayed_onlogin`     TINYINT NOT NULL,
-         `is_displayed_oncentral`   TINYINT NOT NULL,
+         `is_displayed_onlogin`            TINYINT NOT NULL,
+         `is_displayed_oncentral`          TINYINT NOT NULL,
+         `is_displayed_onservicecatalog`   TINYINT NOT NULL DEFAULT 0,
          `display_dates`            TINYINT NOT NULL DEFAULT 1,
          `background_color`         VARCHAR(255) NOT NULL DEFAULT '$white',
          `text_color`               VARCHAR(255) NOT NULL DEFAULT '$dark',
@@ -215,6 +216,11 @@ function plugin_news_install()
                      ('PluginNewsAlert', 2, 1, 0),
                      ('PluginNewsAlert', 3, 2, 0),
                      ('PluginNewsAlert', 6, 4, 0)");
+    }
+
+    // add displayed on service catalog flag
+    if (!$DB->fieldExists($alert_table, 'is_displayed_onservicecatalog')) {
+        $migration->addField($alert_table, 'is_displayed_onservicecatalog', 'bool');
     }
 
     // add displayed on central flag

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -188,6 +188,15 @@ class PluginNewsAlert extends CommonDBTM
         ];
 
         $tab[] = [
+            'id'            => 11,
+            'table'         => $this->getTable(),
+            'field'         => 'is_displayed_onservicecatalog',
+            'name'          => __s('Show on service catalog page', 'news'),
+            'datatype'      => 'bool',
+            'massiveaction' => false,
+        ];
+
+        $tab[] = [
             'id'       => 10,
             'table'    => $this->getTable(),
             'field'    => 'is_active',
@@ -248,11 +257,12 @@ class PluginNewsAlert extends CommonDBTM
         /** @var DBmysql $DB */
         global $DB;
 
-        $p['show_only_login_alerts']    = false;
-        $p['show_only_central_alerts']  = false;
-        $p['show_hidden_alerts']        = false;
-        $p['show_only_helpdesk_alerts'] = false;
-        $p['entities_id']               = false;
+        $p['show_only_login_alerts']            = false;
+        $p['show_only_central_alerts']          = false;
+        $p['show_hidden_alerts']                = false;
+        $p['show_only_helpdesk_alerts']         = false;
+        $p['show_only_service_catalog_alerts']  = false;
+        $p['entities_id']                       = false;
         foreach ($params as $key => $value) {
             $p[$key] = $value;
         }
@@ -277,12 +287,13 @@ class PluginNewsAlert extends CommonDBTM
         }
 
         // filters for query
-        $targets_sql           = [];
-        $login_sql             = [];
-        $login_show_hidden_sql = ["{$utable}.id" => null];
-        $entity_sql            = [];
-        $show_helpdesk_sql     = [];
-        $show_central_sql      = [];
+        $targets_sql                = [];
+        $login_sql                  = [];
+        $login_show_hidden_sql      = ["{$utable}.id" => null];
+        $entity_sql                 = [];
+        $show_helpdesk_sql          = [];
+        $show_central_sql           = [];
+        $show_service_catalog_sql   = [];
         if (isset($_SESSION['glpiID']) && isset($_SESSION['glpiactiveprofile']['id'])) {
             $targets_sql = [
                 'AND' => [
@@ -331,6 +342,9 @@ class PluginNewsAlert extends CommonDBTM
         //and not the current entity
         if ($p['show_only_helpdesk_alerts']) {
             $show_helpdesk_sql = ["{$table}.is_displayed_onhelpdesk" => 1];
+        }
+        if ($p['show_only_service_catalog_alerts']) {
+            $show_service_catalog_sql = ["{$table}.is_displayed_onservicecatalog" => 1];
         }
         if (!$p['show_only_login_alerts']) {
             $entity_sql = getEntitiesRestrictCriteria($table, '', $p['entities_id'], true);
@@ -393,6 +407,9 @@ class PluginNewsAlert extends CommonDBTM
         }
         if ($show_helpdesk_sql !== []) {
             $criteria['WHERE'][] = $show_helpdesk_sql;
+        }
+        if ($show_service_catalog_sql !== []) {
+            $criteria['WHERE'][] = $show_service_catalog_sql;
         }
         $it = $DB->request($criteria);
         if (count($it) === 0) {
@@ -523,16 +540,22 @@ class PluginNewsAlert extends CommonDBTM
         echo '</th></tr>';
     }
 
+    public static function displayOnServiceCatalog()
+    {
+        self::displayAlerts(['show_only_service_catalog_alerts' => true]);
+    }
+
     public static function displayAlerts($params = [])
     {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
 
-        $p['show_only_login_alerts']    = false;
-        $p['show_only_central_alerts']  = false;
-        $p['show_hidden_alerts']        = false;
-        $p['show_only_helpdesk_alerts'] = false;
-        $p['entities_id']               = false;
+        $p['show_only_login_alerts']           = false;
+        $p['show_only_central_alerts']         = false;
+        $p['show_hidden_alerts']               = false;
+        $p['show_only_helpdesk_alerts']        = false;
+        $p['show_only_service_catalog_alerts'] = false;
+        $p['entities_id']                      = false;
         foreach ($params as $key => $value) {
             $p[$key] = $value;
         }
@@ -545,11 +568,12 @@ class PluginNewsAlert extends CommonDBTM
         }
 
         $hidden_params = [
-            'show_hidden_alerts'        => true,
-            'show_only_login_alerts'    => false,
-            'show_only_central_alerts'  => $p['show_only_central_alerts'],
-            'show_only_helpdesk_alerts' => $p['show_only_helpdesk_alerts'],
-            'entities_id'               => $p['entities_id'],
+            'show_hidden_alerts'               => true,
+            'show_only_login_alerts'           => false,
+            'show_only_central_alerts'         => $p['show_only_central_alerts'],
+            'show_only_helpdesk_alerts'        => $p['show_only_helpdesk_alerts'],
+            'show_only_service_catalog_alerts' => $p['show_only_service_catalog_alerts'],
+            'entities_id'                      => $p['entities_id'],
         ];
 
         if (

--- a/setup.php
+++ b/setup.php
@@ -62,6 +62,9 @@ function plugin_init_news()
         $PLUGIN_HOOKS['display_central']['news'] = [
             'PluginNewsAlert', 'displayOnCentral',
         ];
+        $PLUGIN_HOOKS['display_service_catalog']['news'] = [
+            'PluginNewsAlert', 'displayOnServiceCatalog',
+        ];
         $PLUGIN_HOOKS['pre_item_list']['news'] = ['PluginNewsAlert', 'preItemList'];
 
         $PLUGIN_HOOKS['pre_item_form']['news'] = ['PluginNewsAlert', 'preItemForm'];

--- a/templates/alert_form.html.twig
+++ b/templates/alert_form.html.twig
@@ -84,9 +84,10 @@
     {{ news_fields.checkboxesField(
         "show_on_pages",
         {
-            'is_displayed_oncentral' : __('Central page', 'news'),
-            'is_displayed_onlogin'   : __('Login page', 'news'),
-            'is_displayed_onhelpdesk': __('Helpdesk page', 'news'),
+            'is_displayed_oncentral'        : __('Central page', 'news'),
+            'is_displayed_onlogin'          : __('Login page', 'news'),
+            'is_displayed_onhelpdesk'       : __('Helpdesk page', 'news'),
+            'is_displayed_onservicecatalog' : __('Service catalog page', 'news'),
         },
         item.fields,
         __('Show on pages', 'news'),


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

This PR allows displaying News plugin alerts on Service Catalog page. This request was raised by @PierreTeclib to help partners quickly see important recent GLPI fixes through News alerts on our support.

Note that this feature depends on both update : 
- News plugin update
- GLPI core hook integration on Service Catalog page - related PR : https://github.com/glpi-project/glpi/pull/23952


<img width="1852" height="1097" alt="Capture d’écran du 2026-04-17 11-43-08" src="https://github.com/user-attachments/assets/3d7bd734-901c-48ee-b527-73dff807b747" />
<img width="2017" height="507" alt="Capture d’écran du 2026-04-17 11-43-43" src="https://github.com/user-attachments/assets/461688b4-4d39-4f57-b9a4-89144c87f56c" />

