### PR TITLE
Fix/service catalog update schema mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent a crash on the service catalog page when plugin files are updated before the database schema migration is applied.
+
 ## [1.14.0] - 2026-04-30
 
 ### Added

--- a/inc/alert.class.php
+++ b/inc/alert.class.php
@@ -542,7 +542,19 @@ class PluginNewsAlert extends CommonDBTM
 
     public static function displayOnServiceCatalog()
     {
+        if (!self::hasServiceCatalogDisplayFlag()) {
+            return;
+        }
+
         self::displayAlerts(['show_only_service_catalog_alerts' => true]);
+    }
+
+    private static function hasServiceCatalogDisplayFlag(): bool
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        return $DB->fieldExists(self::getTable(), 'is_displayed_onservicecatalog');
     }
 
     public static function displayAlerts($params = [])

--- a/setup.php
+++ b/setup.php
@@ -42,8 +42,9 @@ function plugin_init_news()
     /**
      * @var array $PLUGIN_HOOKS
      * @var array $CFG_GLPI
+     * @var DBmysql $DB
      */
-    global $PLUGIN_HOOKS, $CFG_GLPI;
+    global $PLUGIN_HOOKS, $CFG_GLPI, $DB;
 
     $PLUGIN_HOOKS['csrf_compliant']['news'] = true;
 
@@ -62,9 +63,11 @@ function plugin_init_news()
         $PLUGIN_HOOKS['display_central']['news'] = [
             'PluginNewsAlert', 'displayOnCentral',
         ];
-        $PLUGIN_HOOKS['display_service_catalog']['news'] = [
-            'PluginNewsAlert', 'displayOnServiceCatalog',
-        ];
+        if ($DB->fieldExists(PluginNewsAlert::getTable(), 'is_displayed_onservicecatalog')) {
+            $PLUGIN_HOOKS['display_service_catalog']['news'] = [
+                'PluginNewsAlert', 'displayOnServiceCatalog',
+            ];
+        }
         $PLUGIN_HOOKS['pre_item_list']['news'] = ['PluginNewsAlert', 'preItemList'];
 
         $PLUGIN_HOOKS['pre_item_form']['news'] = ['PluginNewsAlert', 'preItemForm'];


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #210 
- After the release of the Service Catalog display feature, some clients reported a fatal error on` /ServiceCatalog` during or just after plugin update.
The root cause is a temporary schema mismatch: the code tries to use `is_displayed_onservicecatalog` before this column exists in `glpi_plugin_news_alerts`. Now, instead of a fatal SQL error, the plugin simply does not render alerts on the Service Catalog page until the schema migration is applied.
