### PR TITLE
[Fix]: Alert preview display on readonly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased ##
+
+### Fixed
+
+- Alert preview display in readonly mode
+
 ## [1.14.1] - 2026-06-10
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/templates/alert_form.html.twig
+++ b/templates/alert_form.html.twig
@@ -37,8 +37,10 @@
     {# Horizontal mode solve a few layout problems for this page, such as displaying
        properly a field on an entire row or splitting the layout into 3 columns
        without losing too much space #}
+    {# The 'plugin-news-alert-field' class is used by the preview script below #}
     {% set base_option = {
         'is_horizontal' : false,
+        'add_field_class' : 'plugin-news-alert-field',
     } %}
     {% set base_option_small = {
         'field_class' : 'col-xxl-4 col-xl-6',
@@ -173,6 +175,8 @@
 
     <script>
         (async function () {
+            const $fields = $(".plugin-news-alert-field");
+
             const reload_preview = function () {
                 // Show preview section if hidden
                 $('.preview-section').removeClass('d-none');
@@ -180,10 +184,9 @@
                 // Send tinymce content to the forms textarea
                 tinyMCE.triggerSave();
 
-                // Load preview
                 $(".alert-preview").load(
                     "{{ path('/plugins/news/ajax/alert_preview.php') }}",
-                    $("form[name=asset_form]").serialize()
+                    $fields.find(':input').serialize()
                 );
             };
 
@@ -192,7 +195,7 @@
 
             // Any input or dropdown change on our form
             let updating_template = false;
-            $("form[name=asset_form] :input").on('input', function(e) {
+            $fields.find(':input').on('input', function(e) {
                 if (updating_template) {
                     // Prevent infinite loops as modifying the template will trigger
                     // an update on others fields
@@ -210,19 +213,19 @@
                     }
 
                     // Clear values
-                    $('form[name="asset_form"] input[name="icon"]').prop('checked', false);
-                    $('form[name="asset_form"] input[name="background_color"]').prop('checked', false);
-                    $('form[name="asset_form"] input[name="text_color"]').prop('checked', false);
-                    $('form[name="asset_form"] input[name="emphasis_color"]').prop('checked', false);
+                    $fields.find('input[name="icon"]').prop('checked', false);
+                    $fields.find('input[name="background_color"]').prop('checked', false);
+                    $fields.find('input[name="text_color"]').prop('checked', false);
+                    $fields.find('input[name="emphasis_color"]').prop('checked', false);
 
                     // Apply template values
                     switch ($(e.target).val()) {
                         {% for key, values in templates_values %}
                             case '{{ key }}':
-                                $('form[name="asset_form"] input[name="icon"][value="{{ values.icon }}"]').prop('checked', true);
-                                $('form[name="asset_form"] input[name="background_color"][value="{{ values.background_color }}"]').prop('checked', true);
-                                $('form[name="asset_form"] input[name="text_color"][value="{{ values.text_color }}"]').prop('checked', true);
-                                $('form[name="asset_form"] input[name="emphasis_color"][value="{{ values.emphasis_color }}"]').prop('checked', true);
+                                $fields.find('input[name="icon"][value="{{ values.icon }}"]').prop('checked', true);
+                                $fields.find('input[name="background_color"][value="{{ values.background_color }}"]').prop('checked', true);
+                                $fields.find('input[name="text_color"][value="{{ values.text_color }}"]').prop('checked', true);
+                                $fields.find('input[name="emphasis_color"][value="{{ values.emphasis_color }}"]').prop('checked', true);
                                 break;
                         {% endfor %}
                     }
@@ -230,7 +233,7 @@
                     updating_template = false;
                 } else if (['icon', 'background_color', 'text_color', 'emphasis_color'].includes($(e.target).prop('name'))) {
                     // Manual color or icon change, disable templating
-                    $("form[name=asset_form] select[name=type]").val(0).trigger("change");
+                    $fields.find('select[name=type]').val(0).trigger("change");
                 }
 
                 reload_preview_debounced();

--- a/tests/units/PluginNewsAlertTest.php
+++ b/tests/units/PluginNewsAlertTest.php
@@ -30,6 +30,7 @@
 
 namespace GlpiPlugin\News\Tests\Units;
 
+use Glpi\Application\View\TemplateRenderer;
 use Glpi\Tests\DbTestCase;
 use PluginNewsAlert;
 use PluginNewsAlert_User;
@@ -229,5 +230,96 @@ class PluginNewsAlertTest extends DbTestCase
 
         $this->assertSame(PluginNewsAlert_User::VISIBLE, $this->getAlertUserState($alert_user_1_id));
         $this->assertSame(PluginNewsAlert_User::HIDDEN, $this->getAlertUserState($alert_user_2_id));
+    }
+
+    /**
+     * The alert preview script reads the current field values from their
+     * 'plugin-news-alert-field' wrapper rather than from the surrounding <form>,
+     * because that <form> is only rendered when the item is editable (a recursive
+     * alert consulted from a sub-entity is shown read-only, with no <form> at all).
+     * This asserts that the fields keep that marker, and stay usable (not disabled,
+     * carrying their real value), whether or not the item is editable.
+     */
+    public function testAlertPreviewDisplaysWhetherYouCanEditOrNot(): void
+    {
+        $this->login('glpi');
+
+        $alert = $this->createItem(
+            PluginNewsAlert::class,
+            [
+                'name'                          => 'Recursive alert',
+                'message'                       => 'Alert preview content',
+                'type'                          => 1,
+                'size'                          => 'medium',
+                'icon'                          => 'settings',
+                'background_color'              => 'white',
+                'text_color'                    => 'dark',
+                'emphasis_color'                => 'dark',
+                'is_active'                     => 1,
+                'entities_id'                   => 0,
+                'is_close_allowed'              => 1,
+                'is_displayed_onlogin'          => 0,
+                'is_displayed_oncentral'        => 0,
+                'is_displayed_onhelpdesk'       => 0,
+                'is_displayed_onservicecatalog' => 0,
+
+            ],
+        );
+
+        $render = function () use ($alert): string {
+            return TemplateRenderer::getInstance()->render('@news/alert_form.html.twig', [
+                'item'             => $alert,
+                'templates'        => PluginNewsAlert::getTypes(),
+                'sizes'            => PluginNewsAlert::getSizes(),
+                'colors'           => PluginNewsAlert::getColors(),
+                'icons'            => PluginNewsAlert::getIcons(),
+                'templates_values' => PluginNewsAlert::getTemplatesValues(),
+            ]);
+        };
+
+        //Both scenarios will ensure that plugin-news-alert-field class is present,
+        // as it ensures our fields values are carried to the backend.
+
+        // First scenario: Render template in editable mode, we check the form is present.
+        $editable_html = $render();
+        $this->assertStringContainsString('name="asset_form"', $editable_html);
+        $this->assertStringContainsString('plugin-news-alert-field', $editable_html);
+        $this->assertStringContainsString('name="message"', $editable_html);
+        $this->assertStringContainsString('Alert preview content', $editable_html);
+
+        // Second scenario: Render template in readonly mode, we check the form is absent
+        $profile = $this->createItem(\Profile::class, [
+            'name'      => 'News read-only',
+            'interface' => 'central',
+        ]);
+        $readonly_user = $this->createItem(User::class, [
+            'name' => 'news_readonly_user',
+        ]);
+        $this->createItem(\Profile_User::class, [
+            'users_id'    => $readonly_user->getID(),
+            'profiles_id' => $profile->getID(),
+            'entities_id' => 0,
+        ]);
+
+        global $DB;
+        $DB->update(\ProfileRight::getTable(), ['rights' => 0], ['profiles_id' => $profile->getID()]);
+        \ProfileRight::updateProfileRights($profile->getID(), [
+            PluginNewsAlert::$rightname => READ,
+        ]);
+
+        $this->login('news_readonly_user');
+        $this->assertFalse($alert->canEdit($alert->getID()));
+
+        $readonly_html = $render();
+        $this->assertStringNotContainsString('name="asset_form"', $readonly_html);
+        $this->assertStringContainsString('plugin-news-alert-field', $readonly_html);
+        $this->assertStringContainsString('name="message"', $readonly_html);
+        $this->assertStringContainsString('Alert preview content', $readonly_html);
+
+        // The checked "background_color" radio must not be disabled, or jQuery's
+        // serialize() (used by the preview script) would silently drop it.
+        $found = preg_match('/<input[^>]*name="background_color"[^>]*checked[^>]*>/', $readonly_html, $matches);
+        $this->assertSame(1, $found);
+        $this->assertStringNotContainsString('disabled', $matches[0]);
     }
 }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45982
- Here is a brief description of what this PR does:
  - Update alert_form template to make sure it doesn't pass an empty data array to the backend in both readonly and edit mode. Passing an empty data array was causing a 500 error in **PluginNewsAlert->displayAlert()**, as the method was missing a mandatory variable.

> [!IMPORTANT]
> There is no front end-to-end test as none curtrently exist for this plugin, and I found it a bit overkill to implement a whole cypress testsuit for this minor fix. Instead I rendered the template from both readonly and editable contexts and checked that my changes were in place in both cases.


## Screenshots (if appropriate):
<img width="2120" height="1307" alt="image" src="https://github.com/user-attachments/assets/ef190ddb-2a3c-49e9-b601-ccd60a349620" />
Alert is in root entity and I'm visualizing it from a sub-entity => Readonly mode